### PR TITLE
fix: Fix Index Layer and Consenus Layer

### DIFF
--- a/internal/blockchain/merkle_tree.go
+++ b/internal/blockchain/merkle_tree.go
@@ -29,15 +29,19 @@ func NewMerkleTree(data [][]byte) *MerkleTree {
 		nodes = append(nodes, *node)
 	}
 
-	for i := 0; i < len(data)/2; i++ {
+	for len(nodes) > 1 {
 		var newLevel []MerkleNode
 
-		for j := 0; j < len(nodes); j += 2 {
-			node := NewMerkleNode(&nodes[j], &nodes[j+1], nil)
+		for i := 0; i < len(nodes)-1; i += 2 {
+			node := NewMerkleNode(&nodes[i], &nodes[i+1], nil)
 			newLevel = append(newLevel, *node)
 		}
 
 		nodes = newLevel
+	}
+
+	if len(nodes) == 0 {
+		return nil
 	}
 
 	mTree := MerkleTree{&nodes[0]}

--- a/internal/consensus/pos.go
+++ b/internal/consensus/pos.go
@@ -8,11 +8,12 @@ func GetSlotLeaderUtil(registryKeys [][]byte, stakeData map[string]int, epochRan
 	revealedValues := RevealPhase(epochRandoms)
 	seed := RecoveryPhase(revealedValues)
 
-	stakeProbs := GetStakes(stakeData)
 	cumulativeProb := 0.0
 
-	for _, registry := range registryKeys {
+	for index, registry := range registryKeys {
 		registryStr := hex.EncodeToString(registry)
+		stakeProbs := GetStakes(stakeData, index)
+		
 		prob := stakeProbs[registryStr]
 		cumulativeProb += prob
 
@@ -25,10 +26,17 @@ func GetSlotLeaderUtil(registryKeys [][]byte, stakeData map[string]int, epochRan
 	return lastRegistry
 }
 
-func GetStakes(stakeData map[string]int) map[string]float64 {
+func GetStakes(stakeData map[string]int, index int) map[string]float64 {
 	sum := 0.0
-	for _, numDomains := range stakeData {
-		sum += float64(numDomains)
+
+	// create a slice of the keys
+	keys := make([]string, 0, len(stakeData))
+    for k := range stakeData {
+        keys = append(keys, k)
+    }
+
+	for i := index; i < len(keys); i++ {
+		sum += float64(stakeData[keys[i]])
 	}
 
 	stakeProbs := make(map[string]float64)
@@ -42,8 +50,9 @@ func GetStakes(stakeData map[string]int) map[string]float64 {
 		return stakeProbs
 	}
 
-	for registry, numDomains := range stakeData {
-		stakeProbs[registry] = float64(numDomains) / sum
+	for i := index; i < len(keys); i++ {
+		registry := keys[i]
+		stakeProbs[registry] = float64(stakeData[registry]) / sum
 	}
 
 	return stakeProbs

--- a/sims/gossip.go
+++ b/sims/gossip.go
@@ -12,7 +12,7 @@ import (
 
 func SimGossip() {
 	// Constants
-	const numNodes = 4
+	const numNodes = 6
 	const epochInterval = 10
 	const seed = 0
 	var wg sync.WaitGroup


### PR DESCRIPTION
- Minor fixes to the index layer since the current implementation could not handle combining nodes at different levels, leading to this error.
```
panic: runtime error: index out of range [3] with length 3

goroutine 1132 [running]:
github.com/bleasey/bdns/internal/blockchain.NewMerkleTree({0xc000ce80c0?, 0xc000001ec0?, 0xc00010d7e8?}) 
        DefaultHomePath/bdns/internal/blockchain/merkle_tree.go:36 +0x465
github.com/bleasey/bdns/internal/blockchain.(*Block).SetupMerkleTree(0x0?)
        DefaultHomePath/bdns/internal/blockchain/block.go:214 +0x199
github.com/bleasey/bdns/internal/blockchain.NewBlock(0x1, {0xc0003eb560, 0x5b, 0x5b}, {0x0, 0x0, 0x0}, {0xc000126808, 0x6, 0x9}, ...)
        DefaultHomePath/bdns/internal/blockchain/block.go:39 +0x167
github.com/bleasey/bdns/internal/network.(*Node).CreateBlockIfLeader(0xc0003b29c0, 0xc0007ddfb8?)        
        DefaultHomePath/bdns/internal/network/node_helper.go:130 +0x7d0
created by github.com/bleasey/bdns/internal/network.(*Node).InitializeNodeAsync in goroutine 1
        DefaultHomePath/bdns/internal/network/simulation.go:75 +0x18e
exit status 2
```
- Fix the consensus layer to ignore the stake information of a registry not chosen as the leader for the current epoch.